### PR TITLE
fix pod fetching - running statuses first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ catalog2.json
 kubectl
 .kube.config
 .storefrontcloud.config
+*.cache
+/node_modules/

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -32,6 +32,7 @@ const logger = createLogger({
 const KUBECONFIG_PATH = path.resolve('.kube.config')
 const CONFIG_PATH = path.resolve('.storefrontcloud.config')
 const PODS_CACHE_PATH = path.resolve('.storefrontcloud.pods.cache')
+const PHASE_RUNNING = 'Running'
 let PODS_CACHE = []
 let CONTEXT = { // defaults
   is_kubeconfig_a_file: true,
@@ -93,7 +94,11 @@ const outputPodsList = (items, CONTEXT, format = '') => {
 }
 const guessByRole = (role, PODS_CACHE, CONTEXT) => {
   if (role === 'pod') return CONTEXT.current_pod
-  const filteredPods = PODS_CACHE.filter(i => i.role === role)
+  const filteredPods = PODS_CACHE.filter(i => i.role === role).sort((podA, podB) => {
+    if (podA.status.phase === podB.status.phase) return 0
+    if (podA.status.phase === PHASE_RUNNING) return -1
+    return 1
+  })
   if (filteredPods.length > 0) return filteredPods[0].metadata.name; else return role
 }
 


### PR DESCRIPTION
Resolves problem on multiple pods of same role, where some of them failed. Now orders them to get Running pods first.

Problem:
![cli-problem](https://user-images.githubusercontent.com/13100280/50862286-901a1d80-139b-11e9-93d3-91b18ad91040.PNG)

generated:
```
node .\scripts\cli.js clearCache
error: cannot exec into a container in a completed pod; current phase is Failed
```
